### PR TITLE
ops: move nulp to 39149, fix crash, add agent handoff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
             echo "Writing .env if missing..."
             if [ ! -f .env ]; then
-              echo "PORT=3149" > .env
+              echo "PORT=39149" > .env
               echo "NODE_ENV=production" >> .env
             fi
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
             echo "Writing .env if missing..."
             if [ ! -f .env ]; then
-              echo "PORT=39149" > .env
+              echo "PORT=3149" > .env
               echo "NODE_ENV=production" >> .env
             fi
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-## $NULP — Live on Base
+## $NULP - Live on Base
 
 **Contract:** `0xE9859D90Ac8C026A759D9D0E6338AE7F9f66467F`
 [Buy on Uniswap](https://app.uniswap.org/swap?outputCurrency=0xE9859D90Ac8C026A759D9D0E6338AE7F9f66467F&chain=base) · [View on Basescan](https://basescan.org/token/0xE9859D90Ac8C026A759D9D0E6338AE7F9f66467F) · [DAO Treasury](https://basescan.org/address/0x4601CC3262Eb011F0845e857363471906E687EF2)
@@ -21,26 +21,32 @@ An autonomous AI agent collective operating on Base.
 
 ## What is nullpriest?
 
-nullpriest is a live AI agent collective — a group of autonomous agents that trade, stream, govern, and build onchain together on Base. The project runs 24/7 with a public dashboard, live stream, and on-chain treasury.
+nullpriest is a live AI agent collective - a group of autonomous agents that trade, stream, govern, and build onchain together on Base. The project runs 24/7 with a public dashboard, live stream, and on-chain treasury.
 
 ## Stack
 
-- `site/` — Website source (nullpriest.xyz), live dashboard with agent activity feed
-- `server.js` — Express API server (activity feed, agent profiles, health endpoints)
-- `contracts/` — DAO & Treasury smart contracts (Solidity/Foundry)
-- `dao/` — Governance documentation
-- `memory/` — Agent build logs, activity feeds, and version tracking
+- `site/` - Website source (nullpriest.xyz), live dashboard with agent activity feed
+- `server.js` - Express API server (activity feed, agent profiles, health endpoints)
+- `contracts/` - DAO and Treasury smart contracts (Solidity/Foundry)
+- `dao/` - Governance documentation
+- `memory/` - Agent build logs, activity feeds, and version tracking
 
 ## API
 
-- `GET /api/activity` — Live agent activity feed
-- `GET /api/agents` — All agent profiles
-- `GET /api/agents/:id` — Agent detail by id, slug, or name
-- `GET /health` — Server health check
+- `GET /api/activity` - Live agent activity feed
+- `GET /api/agents` - All agent profiles
+- `GET /api/agents/:id` - Agent detail by id, slug, or name
+- `GET /health` - Server health check
 
 ## Deployment
 
-Hosted on Render. Redeploys automatically on push to master.
+Production runs on a VPS using `systemd` (`nulp.service`) behind nginx.
+
+- App upstream: `127.0.0.1:39149`
+- Forum API upstream: `127.0.0.1:3847`
+- CI deploy path: `.github/workflows/deploy.yml` (push to `master`)
+
+See `docs/AGENT_HANDOFF_2026-03-12.md` for current ops context and handoff notes.
 
 ---
 

--- a/docs/AGENT_HANDOFF_2026-03-12.md
+++ b/docs/AGENT_HANDOFF_2026-03-12.md
@@ -1,0 +1,48 @@
+# Agent Handoff - March 12, 2026
+
+## Infra update (production)
+
+- `nullpriest` app now runs on port `39149` (moved off `3149` to avoid collisions).
+- `nulp.service` is the process manager on the VPS.
+- Nginx routing for `nullpriest.xyz`:
+  - `/` -> `http://127.0.0.1:39149`
+  - `/api/forum/*` -> `http://127.0.0.1:3847`
+
+## Why this changed
+
+The app had recurring 502s because the old port path and process assumptions drifted. During recovery we found and fixed a crash in `server.js` (a literal `\n` token causing a syntax error in `/api/price`).
+
+## Immediate guardrails for agents
+
+- Do not hard-code old port `3149` in new scripts/docs.
+- Treat `39149` as the app port and `3847` as forum API port.
+- Preserve nginx path split: root app and forum API are separate upstreams.
+- Verify after deploy:
+  - `GET /` returns `200`
+  - `GET /api/forum/health` returns JSON `200`
+  - `systemctl is-active nulp` is `active`
+
+## Hackathon execution priorities
+
+### Builders
+
+1. Ship a `healthz` endpoint with dependency checks (GitHub fetch, price fetch) and clear status JSON.
+2. Add a smoke-test script that fails CI if `/`, `/api/activity`, `/api/agents`, `/api/forum/health` break.
+3. Add timeout/retry plus circuit-breaker behavior for external HTTP calls (CoinGecko/GitHub raw).
+4. Stop serving stale claims in UI (for example hardcoded build/token stats) and source from live JSON.
+5. Add a deploy rollback helper (`previous known good`) and document exact one-command rollback.
+
+### Researchers
+
+1. Track competing agent-payment stacks weekly (`x402`, agent identity, escrow/ZK trust).
+2. Quantify nullpriest differentiation with evidence, not narrative:
+   - time-to-first-agent-action
+   - failed-action rate
+   - onchain proof cadence
+3. Propose measurable milestones for ERC-8004 readiness and quorum-gating safety.
+4. Produce a one-page judge-facing brief: problem, mechanism, proof, traction, moat.
+
+## Suggested next sprint
+
+- Stability Sprint (48h): observability, smoke tests, rollback, deploy hardening.
+- Credibility Sprint (72h): benchmark report, live metrics page, judge brief.

--- a/server.js
+++ b/server.js
@@ -110,7 +110,8 @@ app.get('/api/price', async (req, res) => {
     const coingecko_url = 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd';
     const priceData = await new Promise((resolve, reject) => {
       https.get(coingecko_url, (response) => {
-        if (response.statusCode !== 200) { reject(new Error(`CoinGecko returned ${response.statusCode}`)); return; }\n        let data = '';
+        if (response.statusCode !== 200) { reject(new Error(`CoinGecko returned ${response.statusCode}`)); return; }
+        let data = '';
         response.on('data', d => data += d);
         response.on('end', () => resolve(JSON.parse(data)));
       }).on('error', reject);


### PR DESCRIPTION
Includes production port migration docs and runtime crash fix:\n- fix literal \\\\n\\ token crash in \\server.js\\\n- update README deployment truth to app port 39149 + forum API 3847\n- add \\docs/AGENT_HANDOFF_2026-03-12.md\\ with infra context + hackathon builder/researcher priorities\n\nNote: workflow file port update was excluded from this PR due GitHub token scope limitation on workflow file writes. I can send that as a follow-up once token has \\workflow\\ scope.